### PR TITLE
Vary the gray level resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,10 +114,14 @@ add_executable(diptool
                DownsampleMenu.h
                menus/UpsampleMenu.cpp
                menus/UpsampleMenu.h
+               menus/VaryBitsMenu.cpp
+               menus/VaryBitsMenu.h
                operations/DownsampleOp.cpp
                operations/DownsampleOp.h
                operations/UpsampleOp.cpp
                operations/UpsampleOp.h
+               operations/VaryBitsOp.cpp
+               operations/VaryBitsOp.h
                ${TINYDIALOG}
               )
 

--- a/Menu.cpp
+++ b/Menu.cpp
@@ -54,7 +54,7 @@ void Menu::RenderMenu(sf::Image & image, sf::Texture & texture, sf::Sprite & spr
 
   ImGui::SeparatorText("operations");
 
-  const std::vector<const char*> items_list = {"None", "Downsample", "Upsample"};
+  const std::vector<const char*> items_list = {"None", "Downsample", "Upsample", "Varying Bits"};
 
   ImGui::Combo("##operations", &currentItem, items_list.data(), static_cast<int32_t>(items_list.size()));
 
@@ -69,6 +69,11 @@ bool Menu::IsDownSampleSet() const
 bool Menu::IsUpSampleSet() const
 {
   return (currentItem == 2);
+}
+
+bool Menu::IsVaryingBitsSet() const
+{
+  return (currentItem == 3);
 }
 
 bool Menu::IsOutputAsSourceSet() const

--- a/Menu.h
+++ b/Menu.h
@@ -14,6 +14,7 @@ class Menu {
 
     [[nodiscard]] bool IsDownSampleSet() const;
     [[nodiscard]] bool IsUpSampleSet() const;
+    [[nodiscard]] bool IsVaryingBitsSet() const;
     [[nodiscard]] bool IsOutputAsSourceSet() const;
 
   private:

--- a/main.cpp
+++ b/main.cpp
@@ -331,7 +331,7 @@ void RenderTask(sf::RenderWindow & window
         current_bit_level = varyingbits_menu.BitScale();
 
         std::vector<uint8_t> source_pixels (loaded_image.getPixelsPtr(), (loaded_image.getPixelsPtr()+(loaded_image.getSize().x * loaded_image.getSize().y * 4)));
-        varyingbits_op.ProcessImage(varyingbits_menu.BitScale(), source_pixels, loaded_image.getSize().x, loaded_image.getSize().y, 4);
+        varyingbits_op.ProcessImage(varyingbits_menu.BitScale(), varyingbits_menu.ShiftBitsForContrast(), source_pixels, loaded_image.getSize().x, loaded_image.getSize().y, 4);
 
         const auto & result_image = varyingbits_op.GetImage();
         processed_image.create(varyingbits_op.GetWidth(), varyingbits_op.GetHeight(), result_image.data());

--- a/menus/VaryBitsMenu.cpp
+++ b/menus/VaryBitsMenu.cpp
@@ -1,0 +1,57 @@
+#include "VaryBitsMenu.h"
+
+#include <imgui.h>
+#include <spdlog/spdlog.h>
+
+namespace {
+  bool ButtonCenteredOnLine(const char* label)
+  {
+    constexpr float alignment = 0.5f;
+
+    ImGuiStyle& style = ImGui::GetStyle();
+
+    float size = ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f;
+    float avail = ImGui::GetContentRegionAvail().x;
+
+    float off = (avail - size) * alignment;
+    if (off > 0.0f)
+      ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);
+
+    return ImGui::Button(label);
+  }
+}
+
+void VaryBitsMenu::RenderMenu()
+{
+  ImGui::Begin("Varying Bits Operation", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+
+  ImGui::BeginGroup();
+  ImGui::Text("how many bits to shift (right):");
+  ImGui::SliderInt("##bit_level", &setBit, 0, 7);
+  ImGui::EndGroup();
+
+  ImGui::NewLine();
+
+  if (ButtonCenteredOnLine("save image"))
+  {
+    processBegin = true;
+  }
+
+  ImGui::End();
+}
+
+int32_t VaryBitsMenu::BitScale() const
+{
+  return setBit;
+}
+
+bool VaryBitsMenu::ProcessBegin()
+{
+  bool should_process = processBegin;
+  if (should_process)
+  {
+    processBegin = false;
+  }
+
+  return should_process;
+}

--- a/menus/VaryBitsMenu.cpp
+++ b/menus/VaryBitsMenu.cpp
@@ -26,11 +26,13 @@ void VaryBitsMenu::RenderMenu()
   ImGui::Begin("Varying Bits Operation", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
 
   ImGui::BeginGroup();
-  ImGui::Text("how many bits to shift (right):");
-  ImGui::SliderInt("##bit_level", &setBit, 0, 7);
+  ImGui::Text("Bits Level:");
+  ImGui::SliderInt("##bit_level", &setBit, 8, 1);
   ImGui::EndGroup();
 
   ImGui::NewLine();
+
+  ImGui::Checkbox("contrast bit shift", &shiftBitsContrast);
 
   if (ButtonCenteredOnLine("save image"))
   {
@@ -43,6 +45,11 @@ void VaryBitsMenu::RenderMenu()
 int32_t VaryBitsMenu::BitScale() const
 {
   return setBit;
+}
+
+bool VaryBitsMenu::ShiftBitsForContrast() const
+{
+  return shiftBitsContrast;
 }
 
 bool VaryBitsMenu::ProcessBegin()

--- a/menus/VaryBitsMenu.h
+++ b/menus/VaryBitsMenu.h
@@ -9,9 +9,11 @@ class VaryBitsMenu
 
     void RenderMenu();
     [[nodiscard]] int32_t BitScale() const;
+    bool ShiftBitsForContrast() const;
     bool ProcessBegin();
 
 private:
     bool processBegin = false;
-    int32_t setBit = 0;
+    bool shiftBitsContrast = true;
+    int32_t setBit = 8;
 };

--- a/menus/VaryBitsMenu.h
+++ b/menus/VaryBitsMenu.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+class VaryBitsMenu
+{
+  public:
+    VaryBitsMenu() = default;
+
+    void RenderMenu();
+    [[nodiscard]] int32_t BitScale() const;
+    bool ProcessBegin();
+
+private:
+    bool processBegin = false;
+    int32_t setBit = 0;
+};

--- a/operations/VaryBitsOp.cpp
+++ b/operations/VaryBitsOp.cpp
@@ -1,0 +1,137 @@
+#include "VaryBitsOp.h"
+
+#include <array>
+#include <algorithm>
+#include <limits>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+  std::array<uint8_t, 3> pixel_gather(const int32_t & x
+                                     ,const int32_t & y
+                                     ,const int32_t & w
+                                     ,const int32_t & h
+                                     ,const int32_t & number_of_pixel_neighbors
+                                     ,const int32_t & bpp
+                                     ,const std::vector<uint8_t> & source_image)
+  {
+    int32_t pixel_value_red = 0;
+    int32_t pixel_value_green = 0;
+    int32_t pixel_value_blue = 0;
+
+    for (int32_t i=0; i<(number_of_pixel_neighbors + 1); i++)
+    {
+      const size_t pixel_byte_index_r = ((x + i) * bpp) + (y * w * bpp) + 3;
+      if ((pixel_byte_index_r > 0) && (pixel_byte_index_r < w))
+      {
+        pixel_value_red += static_cast<int32_t>(source_image[((x + i) * bpp) + (y * w * bpp) + 0]);
+        pixel_value_green += static_cast<int32_t>(source_image[((x + i) * bpp) + (y * w * bpp)] + 1);
+        pixel_value_blue += static_cast<int32_t>(source_image[((x + i) * bpp) + (y * w * bpp)] + 2);
+      }
+      else
+      {
+        const int32_t x_fix = std::clamp(x, 0, (w - 1));
+        const int32_t y_fix = std::clamp(y, 0, (h - 1));
+
+        pixel_value_red += static_cast<int32_t>(source_image[(x_fix * bpp) + (y_fix * w * bpp)] + 0);
+        pixel_value_green += static_cast<int32_t>(source_image[(x_fix * bpp) + (y_fix * w * bpp)] + 1);
+        pixel_value_blue += static_cast<int32_t>(source_image[(x_fix * bpp) + (y_fix * w * bpp)] + 2);
+      }
+    }
+
+    pixel_value_red /= (number_of_pixel_neighbors + 1);
+    pixel_value_red = std::clamp(pixel_value_red, 0, static_cast<int32_t>(std::numeric_limits<uint8_t>::max()));
+
+    pixel_value_green /= (number_of_pixel_neighbors + 1);
+    pixel_value_green = std::clamp(pixel_value_green, 0, static_cast<int32_t>(std::numeric_limits<uint8_t>::max()));
+
+    pixel_value_blue /= (number_of_pixel_neighbors + 1);
+    pixel_value_blue = std::clamp(pixel_value_blue, 0, static_cast<int32_t>(std::numeric_limits<uint8_t>::max()));
+
+    return {static_cast<uint8_t>(pixel_value_red)
+        ,static_cast<uint8_t>(pixel_value_green)
+        ,static_cast<uint8_t>(pixel_value_blue)};
+  }
+
+  void set_pixel(const uint32_t & x
+                ,const uint32_t & y
+                ,const uint32_t & width
+                ,const uint32_t & bpp
+                ,std::vector<uint8_t> & image
+                ,const std::array<uint8_t, 3> & pixel_color_rgb)
+  {
+    image[(x * bpp) + (y * width * bpp) + 0] = pixel_color_rgb[0];
+    image[(x * bpp) + (y * width * bpp) + 1] = pixel_color_rgb[1];
+    image[(x * bpp) + (y * width * bpp) + 2] = pixel_color_rgb[2];
+    image[(x * bpp) + (y * width * bpp) + 3] = 255;
+  }
+}
+
+std::vector<uint8_t> VaryBitsOp::ProcessImage(int32_t bit_level_operation
+                                             ,const std::vector<uint8_t> & source_image
+                                             ,uint32_t width
+                                             ,uint32_t height
+                                             ,uint8_t bpp)
+{
+  spdlog::info("varying bits level: {}", static_cast<uint16_t>(bit_level_operation));
+  BitLevelAlgorithm(source_image, width, height, bpp, bit_level_operation);
+  return result;
+}
+
+const std::vector<uint8_t> & VaryBitsOp::GetImage() const
+{
+  return result;
+}
+
+int32_t VaryBitsOp::GetWidth() const
+{
+  return outWidth;
+}
+
+int32_t VaryBitsOp::GetHeight() const
+{
+  return outHeight;
+}
+
+void VaryBitsOp::BitLevelAlgorithm(const std::vector<uint8_t> & source_image
+                                  ,uint32_t width
+                                  ,uint32_t height
+                                  ,uint8_t bpp
+                                  ,uint8_t bit_level)
+{
+  constexpr uint32_t combine_value = 1;
+  auto dest_result = result = source_image;
+
+  outWidth = static_cast<int32_t>(width);
+  outHeight = static_cast<int32_t>(height);
+
+  for (int32_t i=0; i<height; i++)
+  {
+    for (int32_t j=0; j<width; j++)
+    {
+      // grab the pixel value of the source and set the pixel to the correct destination
+      auto pixel_rgb_value = pixel_gather(j
+                                                               ,i
+                                                               ,static_cast<int32_t>(width)
+                                                               ,static_cast<int32_t>(height)
+                                                               ,combine_value
+                                                               ,bpp
+                                                               ,dest_result);
+
+      if (bit_level > 0)
+      {
+        pixel_rgb_value[0] = (pixel_rgb_value[0] & (0x80 >> bit_level)) > 0 ? pixel_rgb_value[0] & (0xFF >> bit_level) << bit_level : 0;
+        pixel_rgb_value[1] = pixel_rgb_value[0];
+        pixel_rgb_value[2] = pixel_rgb_value[0];
+      }
+
+      set_pixel(j
+               ,i
+               ,static_cast<int32_t>(width)
+               ,bpp
+               ,result
+               ,pixel_rgb_value
+               );
+    }
+  }
+}

--- a/operations/VaryBitsOp.h
+++ b/operations/VaryBitsOp.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class VaryBitsOp
+{
+  public:
+    VaryBitsOp() = default;
+    ~VaryBitsOp() = default;
+
+    std::vector<uint8_t> ProcessImage(int32_t bit_level_operation
+                                     ,const std::vector<uint8_t> & source_image
+                                     ,uint32_t width
+                                     ,uint32_t height
+                                     ,uint8_t bpp);
+
+    [[nodiscard]] const std::vector<uint8_t> & GetImage() const;
+
+    [[nodiscard]] int32_t GetWidth() const;
+    [[nodiscard]] int32_t GetHeight() const;
+
+  private:
+    int32_t outWidth = 0;
+    int32_t outHeight = 0;
+    std::vector<uint8_t> result;
+
+    void BitLevelAlgorithm(const std::vector<uint8_t> & source_image
+                          ,uint32_t width
+                          ,uint32_t height
+                          ,uint8_t bpp
+                          ,uint8_t bit_level);
+
+
+};

--- a/operations/VaryBitsOp.h
+++ b/operations/VaryBitsOp.h
@@ -10,6 +10,7 @@ class VaryBitsOp
     ~VaryBitsOp() = default;
 
     std::vector<uint8_t> ProcessImage(int32_t bit_level_operation
+                                     ,bool bit_contrast
                                      ,const std::vector<uint8_t> & source_image
                                      ,uint32_t width
                                      ,uint32_t height
@@ -29,7 +30,8 @@ class VaryBitsOp
                           ,uint32_t width
                           ,uint32_t height
                           ,uint8_t bpp
-                          ,uint8_t bit_level);
+                          ,uint32_t bit_level
+                          ,bool bit_contrast);
 
 
 };


### PR DESCRIPTION
Vary the gray level resolution of your image from 8-bit to a 1-bit image in steps of 1-bits. Let the user decide how many number of bits or provide a selection from a drop-down menu.