### PR TITLE
Fix loading file fitting

### DIFF
--- a/Menu.cpp
+++ b/Menu.cpp
@@ -33,7 +33,7 @@ void Menu::RenderMenu(sf::Image & image, sf::Texture & texture, sf::Sprite & spr
     {
       spdlog::info("New image loaded");
       texture.loadFromImage(image);
-      sprite.setTexture(texture);
+      sprite.setTexture(texture, true);
       sprite.setPosition(8, 8);
     }
     else

--- a/menus/VaryBitsMenu.h
+++ b/menus/VaryBitsMenu.h
@@ -9,7 +9,7 @@ class VaryBitsMenu
 
     void RenderMenu();
     [[nodiscard]] int32_t BitScale() const;
-    bool ShiftBitsForContrast() const;
+    [[nodiscard]] bool ShiftBitsForContrast() const;
     bool ProcessBegin();
 
 private:


### PR DESCRIPTION
When loading an image file in the editor the sprite doesn't seem to resize. This is because the texture class has a parameter that needs to be set to true when replacing the data in it.