### PR TITLE
Local Enhance Not Waiting For Thread Pool Crash

### DIFF
--- a/operations/HistogramEqualizationOp.cpp
+++ b/operations/HistogramEqualizationOp.cpp
@@ -456,18 +456,19 @@ void HistogramEqualizationOp::LocalizeEnhancementProcess(const std::vector<uint8
         });
       }
     }
-
-    auto work_done = std::async([&](){
-      float work_completed = 0.0f;
-      while(work_completed < 1.0f)
-      {
-        work_completed = (static_cast<float>(outWidth * outHeight) - static_cast<float>(workPool.numberofjobs())) / static_cast<float>(outWidth * outHeight);
-        spdlog::info("histogram work completed: {:.2f}%", work_completed * 100.0f);
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-      }
-    });
-
-    workPool.waitforthread();
-    work_done.wait();
   }
+
+  auto work_done = std::async([&](){
+    float work_completed = 0.0f;
+    while(work_completed < 1.0f)
+    {
+      work_completed = (static_cast<float>(outWidth * outHeight) - static_cast<float>(workPool.numberofjobs())) / static_cast<float>(outWidth * outHeight);
+      spdlog::info("histogram work completed: {:.2f}%", work_completed * 100.0f);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+  });
+
+  workPool.waitforthread();
+  work_done.wait();
+
 }

--- a/operations/HistogramOp.cpp
+++ b/operations/HistogramOp.cpp
@@ -170,7 +170,7 @@ std::tuple<std::map<int32_t, std::vector<int32_t>>, int32_t, int32_t> HistogramO
       int32_t ii = std::clamp(i, static_cast<int32_t>(0), static_cast<int32_t>(width)-1);
       int32_t jj = std::clamp(j, static_cast<int32_t>(0), static_cast<int32_t>(height)-1);
       int32_t pixel_value = 0;
-      if (sum_count > 1)
+      if (sum_count > 0)
       {
         for (size_t k = 0; k < sum_count; k++)
         {


### PR DESCRIPTION
The local enhance function when call is supposed to wait until all jobs in the thread pool queue has completed. This seems to not be the case causing the local enhance function to complete which makes a lot of local variables go out of scope causing inaccessible memory and then crashing.

This seems to be caused by cthreadpool::waitforthread function not being called for the grayscale path